### PR TITLE
fix bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ ARG DAVINCI_ZIP=davinci-assembly_3.0.1-0.3.1-SNAPSHOT-dist-beta.9.zip
 RUN cd / \
 	&& mkdir -p /opt/davinci \
 	&& wget https://github.com/edp963/davinci/releases/download/v0.3.0-beta.9/$DAVINCI_ZIP \
-	&& unzip $DAVINCI_ZIP -d /opt/davinci\
+	&& tar -xf $DAVINCI_ZIP -d /opt/davinci\
 	&& rm -rf $DAVINCI_ZIP \
 	&& cp -v /opt/davinci/config/application.yml.example /opt/davinci/config/application.yml
 
 RUN mkdir -p /opt/phantomjs-2.1.1 \
     && wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-	&& unzip phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+	&& tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
 	&& rm -rf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
 	&& mv phantomjs-2.1.1-linux-x86_64/bin/phantomjs /opt/phantomjs-2.1.1/phantomjs \
 	&& rm -rf phantomjs-2.1.1-linux-x86_64

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ LABEL MAINTAINER="edp_support@groups.163.com"
 RUN cd / \
 	&& mkdir -p /opt/davinci \
 	&& wget https://github.com/edp963/davinci/releases/download/v0.3.0-beta.9/davinci-assembly_3.0.1-0.3.1-SNAPSHOT-dist-beta.9.zip \
-	&& unzip davinci-assembly_3.0.1-0.3.1-SNAPSHOT-dist-beta.9.zip -d /opt/davinci\
+	&& tar -xf davinci-assembly_3.0.1-0.3.1-SNAPSHOT-dist-beta.9.zip -d /opt/davinci\
 	&& rm -rf davinci-assembly_3.0.1-0.3.1-SNAPSHOT-dist-beta.9.zip
 
 # 将phantomjs打包到镜像
 
 RUN mkdir -p /opt/phantomjs-2.1.1 \
     && wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-	&& unzip phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+	&& tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
 	&& rm -rf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
 	&& mv phantomjs-2.1.1-linux-x86_64/bin/phantomjs /opt/phantomjs-2.1.1/phantomjs \
 	&& rm -rf phantomjs-2.1.1-linux-x86_64

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ version: '3.6'
 services:
   davinci:
     environment:
+      # TZ is TIME_ZONE , you can set your local time zone, or no use it(delete it)
+      - TZ=Asia/Shanghai
       - SERVER_ADDRESS=0.0.0.0
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/davinci0.3?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&allowMultiQueries=true
       - SPRING_DATASOURCE_USERNAME=root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
   davinci:
     environment:
-      - TIME_ZONE=Asia/Shanghai
+      - TZ=Asia/Shanghai
       - SERVER_ADDRESS=0.0.0.0
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/davinci0.3?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&allowMultiQueries=true
       - SPRING_DATASOURCE_USERNAME=root


### PR DESCRIPTION
1、unzip not work
location:  Dockerfile. 
In CentOS 7,  docker build can not work. The error message said it did not support( I guess the base image "openjdk:8u242-jdk" no support this command).  I use "tar -xf" replace "unzip" , then it work.
2、TIME_ZONE not work
location:  docker-compose.yml.  
use TZ replace TIME_ZONE,  it works and i can see the current local time in docker container.

